### PR TITLE
fix: Remove content type from API request

### DIFF
--- a/src/rotki.rs
+++ b/src/rotki.rs
@@ -41,7 +41,7 @@ async fn request(client: &reqwest::Client, url: &String) -> anyhow::Result<reqwe
     Ok(client
         .get(url)
         .headers(tracing_headers)
-        .header("content-type", "application/json")
+        .header("user-agent", "simplefin-rotki")
         .send()
         .await?)
 }


### PR DESCRIPTION
Include user-agent though to ease debugging.

This seems to break Rotki after some Rotki update. Removing it fixes the problem though :shrug:

I need to figure out more before making a bug report upstream